### PR TITLE
Fixed some errors causing ClassCastExceptions

### DIFF
--- a/src/net/dhleong/acl/protocol/core/world/GenericUpdatePacket.java
+++ b/src/net/dhleong/acl/protocol/core/world/GenericUpdatePacket.java
@@ -22,7 +22,7 @@ import net.dhleong.acl.world.ArtemisObject;
 public class GenericUpdatePacket extends BaseArtemisPacket implements ObjectUpdatingPacket {
 	private static ObjectType[] GENERIC_TYPES = {
 		ObjectType.MINE, ObjectType.ANOMALY, ObjectType.TORPEDO,
-		ObjectType.BLACK_HOLE, ObjectType.ASTEROID
+		ObjectType.BLACK_HOLE, ObjectType.ASTEROID, ObjectType.MONSTER
 	};
 
 	private static final byte[] UNK_TORPEDO = { 0 };

--- a/src/net/dhleong/acl/protocol/core/world/MainPlayerUpdatePacket.java
+++ b/src/net/dhleong/acl/protocol/core/world/MainPlayerUpdatePacket.java
@@ -42,7 +42,7 @@ public class MainPlayerUpdatePacket extends BaseArtemisPacket implements ObjectU
 	}
 
     private enum Bit {
-    	UNK_1_1,
+    	WEAPONS_TARGET,
     	IMPULSE,
     	RUDDER,
     	TOP_SPEED,
@@ -94,8 +94,8 @@ public class MainPlayerUpdatePacket extends BaseArtemisPacket implements ObjectU
 
     	while (reader.hasMore()) {
     		reader.startObject(Bit.values());
-    		reader.readObjectUnknown(Bit.UNK_1_1, 4);
 
+            int weaponsTarget = reader.readInt(Bit.WEAPONS_TARGET, -1);
     		float impulseSlider = reader.readFloat(Bit.IMPULSE, -1); 
             float steeringSlider = reader.readFloat(Bit.RUDDER, -1);
             float topSpeed = reader.readFloat(Bit.TOP_SPEED, -1);
@@ -177,6 +177,7 @@ public class MainPlayerUpdatePacket extends BaseArtemisPacket implements ObjectU
             player.setAvailableCoolant(availableCoolant);
             player.setScienceTarget(scanTarget);
             player.setCaptainTarget(captainTarget);
+            player.setWeaponsTarget(weaponsTarget);
             player.setScanObjectId(scanningId);
             player.setScanProgress(scanProgress);
             player.setShieldsFront(shieldsFront);
@@ -216,7 +217,7 @@ public class MainPlayerUpdatePacket extends BaseArtemisPacket implements ObjectU
 			int shipIndex = player.getShipIndex();
 			int shipNumber = shipIndex == -1 ? -1 : shipIndex + 1;
 			writer	.startObject(obj, bits)
-					.writeUnknown(Bit.UNK_1_1)
+					.writeInt(Bit.WEAPONS_TARGET, player.getWeaponsTarget(), -1)
 					.writeFloat(Bit.IMPULSE, player.getImpulse(), -1)
 					.writeFloat(Bit.RUDDER, player.getSteering(), -1)
 					.writeFloat(Bit.TOP_SPEED, player.getTopSpeed(), -1)

--- a/src/net/dhleong/acl/vesseldata/Vessel.java
+++ b/src/net/dhleong/acl/vesseldata/Vessel.java
@@ -74,7 +74,7 @@ public class Vessel {
 	}
 
 	public VesselAttribute[] getAttributes() {
-		return (VesselAttribute[]) attributes.toArray();
+		return attributes.toArray(new VesselAttribute[attributes.size()]);
 	}
 
 	public boolean is(VesselAttribute attribute) {
@@ -134,11 +134,11 @@ public class Vessel {
 	}
 
 	public BeamPort[] getBeamPorts() {
-		return (BeamPort[]) beamPorts.toArray();
+		return beamPorts.toArray(new BeamPort[beamPorts.size()]);
 	}
 
 	public VesselPoint[] getTorepedoTubes() {
-		return (BeamPort[]) torpedoTubes.toArray();
+		return torpedoTubes.toArray(new VesselPoint[torpedoTubes.size()]);
 	}
 
 	public int getTorpedoStorage(OrdnanceType type) {
@@ -150,14 +150,14 @@ public class Vessel {
 	}
 
 	public VesselPoint[] getEnginePorts() {
-		return (VesselPoint[]) enginePorts.toArray();
+		return enginePorts.toArray(new VesselPoint[enginePorts.size()]);
 	}
 
 	public VesselPoint[] getImpulsePoints() {
-		return (VesselPoint[]) impulsePoints.toArray();
+		return impulsePoints.toArray(new VesselPoint[impulsePoints.size()]);
 	}
 
 	public VesselPoint[] getManeuverPoints() {
-		return (VesselPoint[]) maneuverPoints.toArray();
+		return maneuverPoints.toArray(new VesselPoint[maneuverPoints.size()]);
 	}
 }

--- a/src/net/dhleong/acl/world/ArtemisPlayer.java
+++ b/src/net/dhleong/acl/world/ArtemisPlayer.java
@@ -30,6 +30,7 @@ public class ArtemisPlayer extends BaseArtemisShip {
     private int mDockingBase = -1;
     private MainScreenView mMainScreen;
     private int mAvailableCoolant = -1;
+    private int mWeaponsTarget = -1;
     private float mImpulse = -1;
     private byte mWarp = -1;
     private BeamFrequency mBeamFreq;
@@ -407,6 +408,19 @@ public class ArtemisPlayer extends BaseArtemisShip {
     }
 
     /**
+     * The ID of the object targeted by the weapons officer. If the target is
+     * cleared, this method returns 1.
+     * Unspecified: -1
+     */
+    public int getWeaponsTarget() {
+        return mWeaponsTarget;
+    }
+
+    public void setWeaponsTarget(int weaponsTarget) {
+        mWeaponsTarget = weaponsTarget;
+    }
+
+    /**
      * The ID of the object being scanned. Note that this is distinct from the
      * science target: science can start a scan then change targets, but the
      * scan continues on the original target.
@@ -446,6 +460,10 @@ public class ArtemisPlayer extends BaseArtemisShip {
             
             if (BoolState.isKnown(plr.mAutoBeams)) {
             	mAutoBeams = plr.mAutoBeams;
+            }
+
+            if (plr.mWeaponsTarget != -1) {
+                mWeaponsTarget = plr.mWeaponsTarget;
             }
 
             if (plr.mImpulse != -1) {


### PR DESCRIPTION
Casting Object[] to an array of a different type causes a ClassCastException during runtime (at least on my computer); using the version of toArray that takes an array as an argument fixes this problem.